### PR TITLE
feat: verbose input and customizable tool_name for GitHub PR reviews

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -69,6 +69,9 @@ inputs:
 runs:
   using: "composite"
   steps:
+    - uses: actions/setup-node@v4
+      with:
+        node-version: '>=12'
     - run: $GITHUB_ACTION_PATH/script.sh
       shell: bash
       env:

--- a/action.yml
+++ b/action.yml
@@ -66,6 +66,9 @@ inputs:
   pyright_flags:
     description: "Extra arguments; can be used to specify specific files to check."
     required: false
+  verbose:
+    description: 'Verbose mode'
+    default: 'false'
 runs:
   using: "composite"
   steps:
@@ -95,6 +98,7 @@ runs:
         INPUT_PROJECT: ${{ inputs.project }}
         INPUT_LIB: ${{ inputs.lib }}
         INPUT_PYRIGHT_FLAGS: ${{ inputs.pyright_flags }}
+        INPUT_VERBOSE: ${{ inputs.verbose }}
 branding:
   icon: "alert-octagon"
   color: "blue"

--- a/pyright_to_rdjson/pyright_to_rdjson.py
+++ b/pyright_to_rdjson/pyright_to_rdjson.py
@@ -1,52 +1,61 @@
 import json
+import os
 import sys
-
 from typing import Any, Dict, TextIO
 
 
-def pyright_to_rdjson(jsonin: TextIO):
-    pyright: Dict = json.load(jsonin)
-
+def validate_pyright_json(pyright: Dict) -> None:
+    """Validate if the input JSON contains pyright diagnostics."""
     if "generalDiagnostics" not in pyright:
         raise RuntimeError("This doesn't look like pyright json")
 
-    rdjson: Dict[str, Any] = {
-        "source": {"name": "pyright", "url": "https://github.com/Microsoft/pyright"},
-        "severity": "WARNING",
-        "diagnostics": [],
+
+def convert_range(range_info: Dict[str, Dict[str, int]]) -> Dict[str, Dict[str, int]]:
+    """Convert zero-based offsets from pyright to one-based for rdjson."""
+    return {
+        "start": {
+            "line": range_info["start"]["line"] + 1,
+            "column": range_info["start"]["character"] + 1,
+        },
+        "end": {
+            "line": range_info["end"]["line"] + 1,
+            "column": range_info["end"]["character"] + 1,
+        },
     }
 
-    d: Dict
-    for d in pyright["generalDiagnostics"]:
-        message = d["message"]
 
-        # If there is a rule name, append it to the message
-        rule = d.get("rule", None)
-        if rule is not None:
-            message = f"{message} ({rule})"
+def create_diagnostic_entry(diagnostic: Dict[str, Any]) -> Dict[str, Any]:
+    """Create an rdjson diagnostic entry from a pyright diagnostic."""
+    message = diagnostic["message"]
+    rule = diagnostic.get("rule")
 
-        rdjson["diagnostics"].append(
-            {
-                "message": message,
-                "severity": d["severity"].upper(),
-                "location": {
-                    "path": d["file"],
-                    "range": {
-                        "start": {
-                            # pyright uses zero-based offsets
-                            "line": d["range"]["start"]["line"] + 1,
-                            "column": d["range"]["start"]["character"] + 1,
-                        },
-                        "end": {
-                            "line": d["range"]["end"]["line"] + 1,
-                            "column": d["range"]["end"]["character"] + 1,
-                        },
-                    },
-                },
-            }
-        )
+    if rule:
+        message = f"{message} ({rule})"
 
-    return json.dumps(rdjson)
+    return {
+        "message": message,
+        "severity": diagnostic["severity"].upper(),
+        "location": {
+            "path": diagnostic["file"],
+            "range": convert_range(diagnostic["range"]),
+        },
+    }
+
+
+def pyright_to_rdjson(jsonin: TextIO) -> str:
+    """Convert pyright JSON diagnostics to rdjson format."""
+    pyright: Dict[str, Any] = json.load(jsonin)
+    tool_name: str = os.getenv("INPUT_TOOL_NAME", "pyright")
+    validate_pyright_json(pyright)
+    rdjson: Dict[str, Any] = {
+        "source": {"name": tool_name, "url": "https://github.com/Microsoft/pyright"},
+        "severity": "WARNING",
+        "diagnostics": [
+            create_diagnostic_entry(d) for d in pyright["generalDiagnostics"]
+        ],
+    }
+
+    return json.dumps(rdjson, indent=2)
 
 
 if __name__ == "__main__":

--- a/script.sh
+++ b/script.sh
@@ -15,6 +15,16 @@ echo '::group::🐶 Installing reviewdog ... https://github.com/reviewdog/review
 curl -sfL https://raw.githubusercontent.com/reviewdog/reviewdog/master/install.sh | sh -s -- -b "${TEMP_PATH}" "${REVIEWDOG_VERSION}" 2>&1
 echo '::endgroup::'
 
+print_output() {
+  local file="$1"
+  local label="$2"
+
+  echo "::group:: 🛠️ ${label} ::"
+  cat "$file"
+  echo '::endgroup::'
+}
+
+
 PYRIGHT_ARGS=(--outputjson)
 
 if [ -n "${INPUT_PYTHON_PLATFORM:-}" ]; then
@@ -60,6 +70,13 @@ set -x
 npm exec --yes -- "pyright@${INPUT_PYRIGHT_VERSION}" "${PYRIGHT_ARGS[@]}" ${INPUT_PYRIGHT_FLAGS:-} >"$RDTMP/pyright.json" || true
 
 python3 "${BASE_PATH}/pyright_to_rdjson/pyright_to_rdjson.py" <"$RDTMP/pyright.json" >"$RDTMP/rdjson.json"
+
+[ "${INPUT_VERBOSE:-false}" == "true" ] && {
+  set +x
+  print_output "$RDTMP/pyright.json" "original json output"
+  print_output "$RDTMP/rdjson.json" "converted rdjson output"
+  REVIEWDOG_FLAGS="$REVIEWDOG_FLAGS -tee"
+}
 
 set +e
 # shellcheck disable=SC2086

--- a/script.sh
+++ b/script.sh
@@ -74,12 +74,11 @@ python3 "${BASE_PATH}/pyright_to_rdjson/pyright_to_rdjson.py" <"$RDTMP/pyright.j
 # Configure reviewdog flags
 REVIEWDOG_FLAGS="${INPUT_BANDIT_FLAGS:-}"
 
-[ "${INPUT_VERBOSE:-false}" == "true" ] && {
-  set +x
-  print_output "$RDTMP/pyright.json" "original json output"
-  print_output "$RDTMP/rdjson.json" "converted rdjson output"
-  REVIEWDOG_FLAGS="$REVIEWDOG_FLAGS -tee"
-}
+set +x
+print_output "$RDTMP/pyright.json" "original json output"
+print_output "$RDTMP/rdjson.json" "converted rdjson output"
+REVIEWDOG_FLAGS="$REVIEWDOG_FLAGS -tee"
+
 
 set +e
 # shellcheck disable=SC2086

--- a/script.sh
+++ b/script.sh
@@ -74,10 +74,12 @@ python3 "${BASE_PATH}/pyright_to_rdjson/pyright_to_rdjson.py" <"$RDTMP/pyright.j
 # Configure reviewdog flags
 REVIEWDOG_FLAGS="${INPUT_BANDIT_FLAGS:-}"
 
-set +x
-print_output "$RDTMP/pyright.json" "original json output"
-print_output "$RDTMP/rdjson.json" "converted rdjson output"
-REVIEWDOG_FLAGS="$REVIEWDOG_FLAGS -tee"
+[ "${INPUT_VERBOSE:-false}" == "true" ] && {
+  set +x
+  print_output "$RDTMP/pyright.json" "original json output"
+  print_output "$RDTMP/rdjson.json" "converted rdjson output"
+  REVIEWDOG_FLAGS="$REVIEWDOG_FLAGS -tee"
+}
 
 
 set +e

--- a/script.sh
+++ b/script.sh
@@ -71,6 +71,9 @@ npm exec --yes -- "pyright@${INPUT_PYRIGHT_VERSION}" "${PYRIGHT_ARGS[@]}" ${INPU
 
 python3 "${BASE_PATH}/pyright_to_rdjson/pyright_to_rdjson.py" <"$RDTMP/pyright.json" >"$RDTMP/rdjson.json"
 
+# Configure reviewdog flags
+REVIEWDOG_FLAGS="${INPUT_BANDIT_FLAGS:-}"
+
 [ "${INPUT_VERBOSE:-false}" == "true" ] && {
   set +x
   print_output "$RDTMP/pyright.json" "original json output"
@@ -86,7 +89,7 @@ reviewdog -f=rdjson \
   -filter-mode="${INPUT_FILTER_MODE}" \
   -fail-on-error="${INPUT_FAIL_ON_ERROR}" \
   -level="${INPUT_LEVEL}" \
-  ${INPUT_REVIEWDOG_FLAGS} < "$RDTMP/rdjson.json"
+  ${REVIEWDOG_FLAGS} < "$RDTMP/rdjson.json"
 
 reviewdog_rc=$?
 


### PR DESCRIPTION
- Adds `verbose` input (default: `false`) to enable detailed logs; supports [reviewdog debugging flags](https://github.com/reviewdog/reviewdog?tab=readme-ov-file#debugging) for deeper diagnostics
- Replaces hardcoded `pyright` with configurable `tool_name` input via environment variable `INPUT_TOOL_NAME` for flexible bot naming in GitHub PR reviews